### PR TITLE
Add JSON object with encryption info

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 		"build": "parcel build --no-source-maps src/main.ts"
 	},
 	"dependencies": {
+		"@types/node": "^15.3.0",
 		"crypto-js": "^4.0.0",
 		"notie": "^4.3.1"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,6 +989,11 @@
   resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.5.tgz#4f6648814d0fdcb6a510e3364a9db439a753c4b1"
   integrity sha512-IG8AE1m2pWtPqQ7wXhFhy6Q59bwwnLwO36v5Rit2FrbXCIp8Sk8E2PfUCreyrdo17STwFSKDAkitVuVYbpEHvQ==
 
+"@types/node@^15.3.0":
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
+  integrity sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"


### PR DESCRIPTION
At the moment in the notes is saved just the raw cipher text, but it would be useful to save also other info, such as the tool who encrypted the message, the algorythm used and other settings (like the iterations count for PBKDF2).

With this pull request, an object like that is saved in the notes:
```json
{
   "tool": "https://github.com/makitsune/bitwarden-encrypt-secure-notes",
   "version": "1.0.0",
   "algo": "pbkdf2",
   "iterations": 100000,
   "cipherText": "U2FsdGVkX18DRw5ijk5pEUVPZM5tY1ciznCcmP3ekDY="
}
```

This would allow simpler compatibility with other tools or other versions of this extension, it would allow algorythm and iterations count customization and it would make easier to the user to decrypt the message, in the case after a while he forget what tool he used to encrypt it.